### PR TITLE
Fix pylint issues

### DIFF
--- a/src/asmatch/cache.py
+++ b/src/asmatch/cache.py
@@ -18,11 +18,15 @@ def get_lsh_cache_path(threshold: float) -> str:
 
 def get_db_checksum(session: Session) -> str:
     """Return a checksum representing the current database state."""
-    count = session.exec(select(func.count(Snippet.checksum))).one()
+    # Pylint mis-identifies `func.count` as non-callable in SQLModel
+    count = session.exec(select(func.count(Snippet.checksum))).one()  # pylint: disable=not-callable
     if count == 0:
         return "empty"
 
-    last_snippet = session.exec(select(Snippet).order_by(Snippet.checksum.desc())).first()
+    # `desc` is a SQLAlchemy method generated at runtime
+    last_snippet = session.exec(
+        select(Snippet).order_by(Snippet.checksum.desc())  # pylint: disable=no-member
+    ).first()
     return f"{count}-{last_snippet.checksum}"
 
 def build_lsh_index(session: Session, threshold: float, num_perm: int) -> MinHashLSH:

--- a/tests/test_asmatch.py
+++ b/tests/test_asmatch.py
@@ -1,3 +1,5 @@
+"""Unit tests for the asmatch core module."""
+
 import unittest
 
 from sqlmodel import Session, SQLModel, create_engine, select
@@ -16,6 +18,7 @@ DATABASE_URL = "sqlite:///:memory:"
 engine = create_engine(DATABASE_URL)
 
 class TestAsmatch(unittest.TestCase):
+    """Tests for core snippet operations."""
 
     def setUp(self):
         """Set up a clean database for each test."""
@@ -107,7 +110,7 @@ class TestAsmatch(unittest.TestCase):
             test al, al
             jnz copy_loop
         """
-        num_candidates, matches = find_matches(self.session, query, top_n=1)
+        _num_candidates, matches = find_matches(self.session, query, top_n=1)
 
         self.assertEqual(len(matches), 1)
         # The key of the match should be the checksum


### PR DESCRIPTION
## Summary
- silence pylint false positives in caching utils
- clean up unused return in `update_snippet`
- improve similarity calculations with enumerate
- tweak CLI tests to invoke module directly
- add missing test docstrings

## Testing
- `PYTHONPATH=src pytest -q`
- `pylint $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686bb617493c83279ad0f2e12e4e8564