### PR TITLE
Add module entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ You can manage this file with the `asmatch config` command.
 
 ### 3. Usage
 
-`asmatch` provides a streamlined, action-oriented interface.
+The CLI can be invoked directly with `asmatch` or by running `python -m asmatch`.
+It provides a streamlined, action-oriented interface.
 
 **Examples:**
 ```bash
@@ -122,6 +123,8 @@ asmatch compare <checksum1> <checksum2>
 For a detailed breakdown of all commands and features, see the [User Stories](./docs/user_stories.md) or run:
 ```bash
 asmatch --help
+# or
+python -m asmatch --help
 ```
 
 ### 4. Running Tests

--- a/src/asmatch/__main__.py
+++ b/src/asmatch/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for running `python -m asmatch`."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `src/asmatch/__main__.py` so `python -m asmatch` works
- document module invocation in the README

## Testing
- `PYTHONPATH=src python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_686bc567a5888327a14d5e22c7af78f6