### PR TITLE
Add quiet and verbose CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ asmatch find --query "MOV EAX"
 asmatch compare <checksum1> <checksum2>
 ```
 
+Global options:
+```
+--quiet   Suppress informational output
+--verbose Increase output verbosity
+```
+
 For a detailed breakdown of all commands and features, see the [User Stories](./docs/user_stories.md) or run:
 ```bash
 asmatch --help

--- a/src/asmatch/cli.py
+++ b/src/asmatch/cli.py
@@ -37,7 +37,6 @@ def confirm_action(prompt: str) -> bool:
 
 def main():
     """Entry point for the asmatch command line interface."""
-    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
     # Load configuration
     config = load_config()
 
@@ -47,6 +46,19 @@ def main():
     parser = argparse.ArgumentParser(
         description="A CLI for finding similar assembly code snippets.",
         formatter_class=argparse.RawTextHelpFormatter,
+    )
+    verbosity_group = parser.add_mutually_exclusive_group()
+    verbosity_group.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress informational output.",
+    )
+    verbosity_group.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Increase output verbosity.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -162,6 +174,15 @@ def main():
     )
 
     args = parser.parse_args()
+
+    log_level = logging.INFO
+    if args.quiet:
+        log_level = logging.WARNING
+    elif args.verbose:
+        log_level = logging.DEBUG
+
+    logging.basicConfig(level=log_level, stream=sys.stdout)
+    logger.debug("Running command: %s", args.command)
 
     with Session(engine) as session:
         if args.command == "add":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,12 @@ class TestCLI(unittest.TestCase):
             snippet = Snippet.get_by_name(session, "new_snippet")
             self.assertIsNotNone(snippet)
 
+    def test_quiet_option(self):
+        """Test that --quiet suppresses informational output."""
+        result = self.run_command("--quiet stats")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add --quiet and --verbose global options to CLI
- adjust logging level based on new options
- document new flags in README
- test --quiet behaviour

## Testing
- `PYTHONPATH=src python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_686bc6ac62f4832796d725c4d49c1c7e