### PR TITLE
Improve config persistence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pygments
 datasketch
 rapidfuzz
 tomli
+tomli_w

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "datasketch",
         "rapidfuzz",
         "tomli",
+        "tomli_w",
     ],
     extras_require={
         "dev": ["ruff", "black", "unittest-xml-reporting"],

--- a/src/asmatch/cache.py
+++ b/src/asmatch/cache.py
@@ -1,8 +1,8 @@
 """Utilities for caching and loading the MinHash LSH index."""
 
+import logging
 import os
 import pickle
-import logging
 
 from datasketch import MinHashLSH
 from sqlmodel import Session, func, select

--- a/src/asmatch/cli.py
+++ b/src/asmatch/cli.py
@@ -2,14 +2,14 @@
 
 import argparse
 import json
+import logging
 import os
 import sys
 import time
-import logging
 
 from sqlmodel import Session
 
-from .config import CONFIG_PATH, load_config
+from .config import CONFIG_PATH, load_config, update_config
 from .core import (
     add_snippet,
     compare_snippets,
@@ -361,14 +361,13 @@ def main():
                 for key, value in config.items():
                     logger.info("%s = %s", key, value)
             elif args.config_command == "set":
-                # This is a simplified implementation. A real one would be more robust.
-                config[args.key] = args.value
-                if not os.path.exists(os.path.dirname(CONFIG_PATH)):
-                    os.makedirs(os.path.dirname(CONFIG_PATH))
-                with open(CONFIG_PATH, "w", encoding="utf-8") as f:
-                    # A more robust implementation would use a TOML library to write
-                    f.write(f"{args.key} = {args.value}\n")
-                logger.info("Set %s to %s", args.key, args.value)
+                if args.key == "lsh_threshold":
+                    value = float(args.value)
+                else:
+                    value = int(args.value)
+
+                config = update_config(args.key, value)
+                logger.info("Set %s to %s", args.key, value)
         elif args.command == "compare":
             comparison = compare_snippets(session, args.checksum1, args.checksum2)
 


### PR DESCRIPTION
## Summary
- write config with `tomli_w` for safe updates
- update `asmatch config set` to preserve existing values
- test that `config set` keeps prior settings
- add tomli_w dependency

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc728b86c8327affee940bcbefde4