### PR TITLE
Add mypy and type hints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,5 +21,10 @@ jobs:
           pip install -e .
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
+      - name: Run mypy
+        run: |
+          pip install mypy
+          mypy src/asmatch
+
       - name: Run tests
         run: python -m unittest discover -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,7 @@ select = ["I"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["asmatch"]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true

--- a/src/asmatch/cache.py
+++ b/src/asmatch/cache.py
@@ -1,8 +1,8 @@
 """Utilities for caching and loading the MinHash LSH index."""
 
+import logging
 import os
 import pickle
-import logging
 
 from datasketch import MinHashLSH
 from sqlmodel import Session, func, select
@@ -23,14 +23,15 @@ def get_lsh_cache_path(threshold: float) -> str:
 def get_db_checksum(session: Session) -> str:
     """Return a checksum representing the current database state."""
     # Pylint mis-identifies `func.count` as non-callable in SQLModel
-    count = session.exec(select(func.count(Snippet.checksum))).one()  # pylint: disable=not-callable
+    count = session.exec(select(func.count(Snippet.checksum))).one()  # type: ignore[arg-type]  # pylint: disable=not-callable
     if count == 0:
         return "empty"
 
     # `desc` is a SQLAlchemy method generated at runtime
     last_snippet = session.exec(
-        select(Snippet).order_by(Snippet.checksum.desc())  # pylint: disable=no-member
+        select(Snippet).order_by(Snippet.checksum.desc())  # type: ignore[attr-defined]  # pylint: disable=no-member
     ).first()
+    assert last_snippet is not None
     return f"{count}-{last_snippet.checksum}"
 
 

--- a/src/asmatch/core.py
+++ b/src/asmatch/core.py
@@ -40,7 +40,7 @@ def get_checksum(code_snippet: str) -> str:
     return hashlib.sha256(normalized_string.encode("utf-8")).hexdigest()
 
 
-def get_tokens(code_snippet: str, normalize: bool = True):
+def get_tokens(code_snippet: str, normalize: bool = True) -> list[str]:
     """Return a list of tokens from a code snippet."""
     tokens = lexer.get_tokens(code_snippet)
     output_tokens = []
@@ -230,7 +230,7 @@ def get_snippet_by_checksum(session: Session, checksum: str):
     return Snippet.get_by_checksum(session, checksum)
 
 
-def compare_snippets(session: Session, checksum1: str, checksum2: str) -> dict:
+def compare_snippets(session: Session, checksum1: str, checksum2: str) -> dict | None:
     """Compare two snippets and return similarity metrics."""
     snippet1 = get_snippet_by_checksum(session, checksum1)
     snippet2 = get_snippet_by_checksum(session, checksum2)

--- a/src/asmatch/models.py
+++ b/src/asmatch/models.py
@@ -2,7 +2,7 @@
 
 import json
 import pickle
-from typing import List
+from typing import Sequence
 
 from datasketch import MinHash
 from sqlmodel import Field, Session, SQLModel, select
@@ -17,17 +17,17 @@ class Snippet(SQLModel, table=True):
     minhash: bytes
 
     @property
-    def name_list(self) -> List[str]:
+    def name_list(self) -> list[str]:
         """Return the list of alias names for the snippet."""
         return json.loads(self.names)
 
     @classmethod
-    def get_by_checksum(cls, session: Session, checksum: str) -> "Snippet":
+    def get_by_checksum(cls, session: Session, checksum: str) -> "Snippet | None":
         """Retrieve a snippet by its checksum."""
         return session.get(cls, checksum)
 
     @classmethod
-    def get_by_name(cls, session: Session, name: str) -> "Snippet":
+    def get_by_name(cls, session: Session, name: str) -> "Snippet | None":
         """Return the snippet containing the given name, if any."""
         snippets = session.exec(select(cls)).all()
         for snippet in snippets:
@@ -36,7 +36,7 @@ class Snippet(SQLModel, table=True):
         return None
 
     @classmethod
-    def get_all(cls, session: Session) -> list["Snippet"]:
+    def get_all(cls, session: Session) -> Sequence["Snippet"]:
         """Return all snippets in the database."""
         return session.exec(select(cls)).all()
 


### PR DESCRIPTION
## Summary
- annotate `get_tokens` and related helpers with `list[str]`
- fix models typing so mypy passes
- ignore SQLModel internals where needed
- add mypy configuration
- run mypy in CI workflow

## Testing
- `python -m unittest discover -v`
- `mypy src/asmatch`

------
https://chatgpt.com/codex/tasks/task_e_686bc71a6ab88327a7aeeab8affb021e