### PR TITLE
Add ruff and black checks to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install ruff black
 
       - name: Run mypy
         run: |
           pip install mypy
           mypy src/asmatch
+
+      - name: Run ruff
+        run: ruff check .
+
+      - name: Check formatting with black
+        run: black --check .
 
       - name: Run tests
         run: python -m unittest discover -v

--- a/src/asmatch/cli.py
+++ b/src/asmatch/cli.py
@@ -218,9 +218,9 @@ def main():
                 stats = {
                     "num_imported": snippets_added,
                     "time_elapsed": time_elapsed,
-                    "avg_time_per_snippet": time_elapsed / snippets_added
-                    if snippets_added > 0
-                    else 0,
+                    "avg_time_per_snippet": (
+                        time_elapsed / snippets_added if snippets_added > 0 else 0
+                    ),
                 }
 
                 if args.json:
@@ -243,7 +243,9 @@ def main():
                 try:
                     start, end = map(int, args.range.split("-"))
                 except ValueError:
-                    logger.error("Error: Invalid range format. Use start-end (e.g., 10-30).")
+                    logger.error(
+                        "Error: Invalid range format. Use start-end (e.g., 10-30)."
+                    )
                     return
 
             snippets = list_snippets(session, start, end)
@@ -259,7 +261,9 @@ def main():
                 )
             else:
                 for snippet in snippets:
-                    logger.info("Checksum: %s, Names: %s", snippet.checksum, snippet.name_list)
+                    logger.info(
+                        "Checksum: %s, Names: %s", snippet.checksum, snippet.name_list
+                    )
         elif args.command == "show":
             snippet = get_snippet_by_checksum(session, args.checksum)
             if snippet:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,7 +86,15 @@ class TestCLI(unittest.TestCase):
                 "HOME": home,
             }
             result = subprocess.run(
-                ["python", "-m", "asmatch.cli", "config", "set", "lsh_threshold", "0.7"],
+                [
+                    "python",
+                    "-m",
+                    "asmatch.cli",
+                    "config",
+                    "set",
+                    "lsh_threshold",
+                    "0.7",
+                ],
                 capture_output=True,
                 text=True,
                 env=env,
@@ -109,6 +117,7 @@ class TestCLI(unittest.TestCase):
 
             self.assertEqual(data.get("lsh_threshold"), 0.7)
             self.assertEqual(data.get("top_n"), 10)
+
     def test_quiet_option(self):
         """Test that --quiet suppresses informational output."""
         result = self.run_command("--quiet stats")


### PR DESCRIPTION
## Summary
- lint with `ruff` and format check with `black` in the CI
- fix formatting issues raised by `black`

## Testing
- `ruff check .`
- `black --check .`
- `mypy src/asmatch`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_686bca745334832793d9026ddfc4451f