### PR TITLE
Add env var overrides for cache & config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This approach provides several advantages:
 
 ### LSH Caching
 
-To make searches nearly instantaneous, `asmatch` caches the LSH index to a file in `~/.cache/asmatch/`. The cache is automatically invalidated and rebuilt whenever the database is modified.
+To make searches nearly instantaneous, `asmatch` caches the LSH index to a file in `~/.cache/asmatch/`. The location can be overridden with the `ASMATCH_CACHE_DIR` environment variable. The cache is automatically invalidated and rebuilt whenever the database is modified.
 
 ## How It Works
 
@@ -78,7 +78,7 @@ pip install -e .
 ### 2. Configuration
 
 You can create a configuration file at `~/.config/asmatch/config.toml` to set
-default values.
+default values. Set `ASMATCH_CONFIG_DIR` to override this location.
 
 | Key               | Default | Description |
 |-------------------|--------:|-------------|

--- a/docs/user_stories.md
+++ b/docs/user_stories.md
@@ -132,4 +132,4 @@ This document outlines the features of the `asmatch` CLI from a user's perspecti
 - `asmatch config path` shows the location of the config file.
 - `asmatch config list` displays the current settings.
 - `asmatch config set <key> <value>` sets a new default value.
-- The tool reads default values for `lsh_threshold` and `top_n` from `~/.config/asmatch/config.toml`.
+- The tool reads default values for `lsh_threshold` and `top_n` from `~/.config/asmatch/config.toml`. This location can be changed with the `ASMATCH_CONFIG_DIR` environment variable.

--- a/src/asmatch/cache.py
+++ b/src/asmatch/cache.py
@@ -11,7 +11,8 @@ from .models import Snippet
 
 logger = logging.getLogger(__name__)
 
-CACHE_DIR = os.path.expanduser("~/.cache/asmatch")
+DEFAULT_CACHE_DIR = os.path.expanduser("~/.cache/asmatch")
+CACHE_DIR = os.path.expanduser(os.environ.get("ASMATCH_CACHE_DIR", DEFAULT_CACHE_DIR))
 DB_CHECKSUM_PATH = os.path.join(CACHE_DIR, "db_checksum.txt")
 
 

--- a/src/asmatch/config.py
+++ b/src/asmatch/config.py
@@ -6,7 +6,8 @@ import tempfile
 import tomli
 import tomli_w
 
-CONFIG_DIR = os.path.expanduser("~/.config/asmatch")
+DEFAULT_CONFIG_DIR = os.path.expanduser("~/.config/asmatch")
+CONFIG_DIR = os.path.expanduser(os.environ.get("ASMATCH_CONFIG_DIR", DEFAULT_CONFIG_DIR))
 CONFIG_PATH = os.path.join(CONFIG_DIR, "config.toml")
 
 DEFAULTS = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,18 +29,22 @@ class TestCLI(unittest.TestCase):
         """Clean up the database after each test."""
         os.remove(self.db_name)
 
-    def run_command(self, command):
+    def run_command(self, command, extra_env=None):
         """Helper function to run a command and return the output."""
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.path.join(os.getcwd(), "src"),
+            "DATABASE_URL": f"sqlite:///{self.db_name}",
+        }
+        if extra_env:
+            env.update(extra_env)
+
         result = subprocess.run(
             ["python", "-m", "asmatch.cli", *shlex.split(command)],
             shell=False,
             capture_output=True,
             text=True,
-            env={
-                **os.environ,
-                "PYTHONPATH": os.path.join(os.getcwd(), "src"),
-                "DATABASE_URL": f"sqlite:///{self.db_name}",
-            },
+            env=env,
             check=False,
         )
         return result
@@ -107,8 +111,40 @@ class TestCLI(unittest.TestCase):
             with open(config_path, "rb") as f:
                 data = tomli.load(f)
 
-            self.assertEqual(data.get("lsh_threshold"), 0.7)
-            self.assertEqual(data.get("top_n"), 10)
+        self.assertEqual(data.get("lsh_threshold"), 0.7)
+        self.assertEqual(data.get("top_n"), 10)
+
+    def test_config_dir_env_override(self):
+        """ASMATCH_CONFIG_DIR should override the default config path."""
+        with tempfile.TemporaryDirectory() as cfgdir:
+            result = self.run_command(
+                "config set top_n 7",
+                extra_env={"ASMATCH_CONFIG_DIR": cfgdir},
+            )
+            self.assertEqual(result.returncode, 0)
+
+            config_path = os.path.join(cfgdir, "config.toml")
+            with open(config_path, "rb") as f:
+                data = tomli.load(f)
+
+            self.assertEqual(data.get("top_n"), 7)
+
+            result = self.run_command(
+                "config path",
+                extra_env={"ASMATCH_CONFIG_DIR": cfgdir},
+            )
+            self.assertIn(config_path, result.stdout)
+
+    def test_cache_dir_env_override(self):
+        """ASMATCH_CACHE_DIR should control where cache files are stored."""
+        with tempfile.TemporaryDirectory() as cache_dir:
+            result = self.run_command(
+                "find --query 'MOV EAX, 1'",
+                extra_env={"ASMATCH_CACHE_DIR": cache_dir},
+            )
+            self.assertEqual(result.returncode, 0)
+            cache_file = os.path.join(cache_dir, "lsh_0.50.pkl")
+            self.assertTrue(os.path.exists(cache_file))
     def test_quiet_option(self):
         """Test that --quiet suppresses informational output."""
         result = self.run_command("--quiet stats")


### PR DESCRIPTION
## Summary
- allow overriding cache/config directories via `ASMATCH_CACHE_DIR` and `ASMATCH_CONFIG_DIR`
- update docs with new environment variable options
- cover env var overrides in CLI tests

## Testing
- `ruff check .`
- `mypy --config-file pyproject.toml src/asmatch`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bca894d5c8327a9f0f3b8c235659a